### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:watch": "react-scripts-ts test --env=jsdom",
     "build": "rollup -c",
     "start": "rollup -c -w",
+    "prepublish": "npm run build",
     "prepare": "npm run build"
   },
   "dependencies": {},


### PR DESCRIPTION
- Add `prepublish` script

It makes prevent mistakes like deploying without a build. (just like #1)